### PR TITLE
feat(cli/wkg): wrap wkg publish command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
+ "terminal_size",
 ]
 
 [[package]]
@@ -4274,6 +4275,7 @@ dependencies = [
  "wit-bindgen-rust",
  "wit-component 0.217.0",
  "wit-parser 0.217.0",
+ "wkg",
 ]
 
 [[package]]
@@ -4652,6 +4654,16 @@ source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c
 dependencies = [
  "atty",
  "termcolor",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.37",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6665,6 +6677,27 @@ dependencies = [
  "log",
  "thiserror",
  "wast 35.0.2",
+]
+
+[[package]]
+name = "wkg"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "040ff7688fa0cc366a134afa2e2eefc6728cff41d8f6909715cfc2c38af01c67"
+dependencies = [
+ "anyhow",
+ "clap",
+ "docker_credential",
+ "futures-util",
+ "oci-client",
+ "oci-wasm 0.0.5",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wasm-pkg-client",
+ "wasm-pkg-common 0.5.1",
+ "wit-component 0.216.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ wit-bindgen-rust = { git = "https://github.com/fibonacci1729/wit-bindgen", branc
 wit-bindgen-core = { git = "https://github.com/fibonacci1729/wit-bindgen", branch = "deps" }
 wasm-pkg-common = "0.5.1"
 wasm-pkg-client = "0.5.1"
+wkg = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod add;
 pub mod bindings;
+pub mod publish;

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use clap::Args;
+use std::path::PathBuf;
+use wasm_pkg_client::{Client, Config, PublishOpts};
+use wasm_pkg_common::{package::PackageSpec, registry::Registry};
+
+#[derive(Args, Debug)]
+pub struct PublishCommand {
+    /// The registry domain to use. Overrides configuration file(s).
+    #[arg(long = "registry", value_name = "REGISTRY", env = "WKG_REGISTRY")]
+    registry: Option<Registry>,
+
+    /// The file to publish
+    file: PathBuf,
+
+    /// If not provided, the package name and version will be inferred from the Wasm file.
+    /// Expected format: `<namespace>:<name>@<version>`
+    #[arg(long, env = "WKG_PACKAGE")]
+    package: Option<PackageSpec>,
+}
+
+impl PublishCommand {
+    pub async fn run(self) -> Result<()> {
+        let client = {
+            let config = Config::global_defaults()?;
+            Client::new(config)
+        };
+
+        let package = if let Some(package) = self.package {
+            Some((
+                package.package,
+                package.version.ok_or_else(|| {
+                    anyhow::anyhow!("version is required when manually overriding the package ID")
+                })?,
+            ))
+        } else {
+            None
+        };
+        let (package, version) = client
+            .publish_release_file(
+                &self.file,
+                PublishOpts {
+                    package,
+                    registry: self.registry,
+                },
+            )
+            .await?;
+        println!("Published {}@{}", package, version);
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 
 mod commands;
 mod common;
-use commands::{add::AddCommand, bindings::GenerateBindingsCommand};
+use commands::{add::AddCommand, bindings::GenerateBindingsCommand, publish::PublishCommand};
 
 /// Main CLI structure for command-line argument parsing.
 #[derive(Parser)]
@@ -20,6 +20,9 @@ enum Commands {
     Add(AddCommand),
     /// Generates dependency bindings for selected component
     GenerateBindings(GenerateBindingsCommand),
+
+    /// Publish dependency to a compatible registry
+    Publish(PublishCommand),
 }
 
 #[tokio::main]
@@ -29,6 +32,7 @@ async fn main() -> Result<()> {
     match app.command {
         Commands::Add(cmd) => cmd.run().await?,
         Commands::GenerateBindings(cmd) => cmd.run().await?,
+        Commands::Publish(cmd) => cmd.run().await?,
     }
 
     Ok(())


### PR DESCRIPTION
This commit wraps the `wkg publish` command as `spin deps publish`, so users can have a single CLI tool to publish, add, and generate bindings for component dependencies.