### PR TITLE
Removed unused `wkg` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
- "terminal_size",
 ]
 
 [[package]]
@@ -4275,7 +4274,6 @@ dependencies = [
  "wit-bindgen-rust",
  "wit-component 0.217.0",
  "wit-parser 0.217.0",
- "wkg",
 ]
 
 [[package]]
@@ -4654,16 +4652,6 @@ source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c
 dependencies = [
  "atty",
  "termcolor",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
-dependencies = [
- "rustix 0.38.37",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6677,27 +6665,6 @@ dependencies = [
  "log",
  "thiserror",
  "wast 35.0.2",
-]
-
-[[package]]
-name = "wkg"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040ff7688fa0cc366a134afa2e2eefc6728cff41d8f6909715cfc2c38af01c67"
-dependencies = [
- "anyhow",
- "clap",
- "docker_credential",
- "futures-util",
- "oci-client",
- "oci-wasm 0.0.5",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "wasm-pkg-client",
- "wasm-pkg-common 0.5.1",
- "wit-component 0.216.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ wit-bindgen-rust = { git = "https://github.com/fibonacci1729/wit-bindgen", branc
 wit-bindgen-core = { git = "https://github.com/fibonacci1729/wit-bindgen", branch = "deps" }
 wasm-pkg-common = "0.5.1"
 wasm-pkg-client = "0.5.1"
-wkg = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable


### PR DESCRIPTION
`wkg` gives rise to the following warning:

```
warning: spin-deps v0.1.0 (/home/ivan/github/spin-deps-plugin) ignoring invalid dependency `wkg` which is missing a lib target
```

(The library is `wasm-pkg-tools`, which is already referenced; `wkg` is specifically the CLI.)
