### PR TITLE
chore(.github): bump ubuntu images to 22.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,8 +58,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { target: "x86_64-unknown-linux-gnu", os: "ubuntu-20.04", arch: "amd64", extension: ""}
-          - { target: "aarch64-unknown-linux-gnu", os: "ubuntu-20.04", arch: "aarch64", extension: "", extraArg: "--features openssl/vendored" }
+          - { target: "x86_64-unknown-linux-gnu", os: "ubuntu-22.04", arch: "amd64", extension: ""}
+          - { target: "aarch64-unknown-linux-gnu", os: "ubuntu-22.04", arch: "aarch64", extension: "", extraArg: "--features openssl/vendored" }
           - { target: "x86_64-apple-darwin", os: "macos-13", arch: "amd64", extension: "" }
           - { target: "aarch64-apple-darwin", os: "macos-14", arch: "aarch64", extension: "" }
           - { target: "x86_64-pc-windows-msvc", os: "windows-latest", arch: "amd64", extension: ".exe" }


### PR DESCRIPTION
Bumps the Ubuntu images to 22.04 per the [deprecation of 20.04](https://github.com/actions/runner-images/issues/11101).