### PR TITLE
chore(.github): bump download-artifact to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,7 +134,7 @@ jobs:
         run: echo "RELEASE_VERSION=precanary" >> $GITHUB_ENV
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Display structure of downloaded files
         run: ls -R
       - name: pluginify it


### PR DESCRIPTION
Sorry, missed this spot in https://github.com/fermyon/spin-deps-plugin/pull/20