### PR TITLE
Explore an end-to-end approach to Rust bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
- "gimli 0.28.1",
+ "gimli 0.29.0",
 ]
 
 [[package]]
@@ -167,17 +167,6 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
@@ -290,25 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel 2.3.1",
- "async-io 2.3.4",
- "async-lock 3.4.0",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.3.1",
- "futures-lite 2.3.0",
- "rustix 0.38.37",
- "tracing",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,7 +286,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -351,7 +321,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -376,65 +346,6 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "azure_core"
-version = "0.20.0"
-source = "git+https://github.com/azure/azure-sdk-for-rust?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "dyn-clone",
- "futures",
- "getrandom 0.2.15",
- "http-types",
- "once_cell",
- "paste",
- "pin-project",
- "rand 0.8.5",
- "reqwest 0.12.7",
- "rustc_version",
- "serde 1.0.210",
- "serde_json",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_identity"
-version = "0.20.0"
-source = "git+https://github.com/azure/azure-sdk-for-rust?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
-dependencies = [
- "async-lock 3.4.0",
- "async-process 2.3.0",
- "async-trait",
- "azure_core",
- "futures",
- "oauth2",
- "pin-project",
- "serde 1.0.210",
- "time",
- "tracing",
- "tz-rs",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_security_keyvault"
-version = "0.20.0"
-source = "git+https://github.com/azure/azure-sdk-for-rust?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
-dependencies = [
- "async-trait",
- "azure_core",
- "futures",
- "serde 1.0.210",
- "serde_json",
- "time",
-]
 
 [[package]]
 name = "backtrace"
@@ -532,7 +443,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite 2.3.0",
@@ -605,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbcb16a619d8b8211ed61f42bd290d2a1ac71277a69cf8417ec0996fa92f5211"
 dependencies = [
  "ambient-authority",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -704,7 +615,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -716,7 +627,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -782,12 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const_fn"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,74 +728,86 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.109.0"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6b33d7e757a887989eb18b35712b2a67d96171ec3149d1bfb657b29b7b367c"
+checksum = "69792bd40d21be8059f7c709f44200ded3bbd073df7eb3fa3c282b387c7ffa5b"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
-name = "cranelift-codegen"
-version = "0.109.0"
+name = "cranelift-bitset"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9acf15cb22be42d07c3b57d7856329cb228b7315d385346149df2566ad5e4aa"
-dependencies = [
- "bumpalo",
- "cranelift-bforest",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli 0.28.1",
- "hashbrown 0.14.5",
- "log",
- "regalloc2",
- "rustc-hash 1.1.0",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e934d301392b73b3f8b0540391fb82465a0f179a3cee7c726482ac4727efcc97"
-dependencies = [
- "cranelift-codegen-shared",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb2a2566b3d54b854dfb288b3b187f6d3d17d6f762c92898207eba302931da"
-
-[[package]]
-name = "cranelift-control"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0100f33b704cdacd01ad66ff41f8c5030d57cbff078e2a4e49ab1822591299fa"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
+checksum = "38da1eb6f7d8cdfa92f05acfae63c9a1d7a337e49ce7a2d0769c7fa03a2613a5"
 dependencies = [
  "serde 1.0.210",
  "serde_derive",
 ]
 
 [[package]]
-name = "cranelift-frontend"
-version = "0.109.0"
+name = "cranelift-codegen"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f74b84f16af2e982b0c0c72233503d9d55cbfe3865dbe807ca28dc6642a28b5"
+checksum = "709f5567a2bff9f06edf911a7cb5ebb091e4c81701714dc6ab574d08b4a69a0d"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.29.0",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.112.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d39a6b194c069fd091ca1f17b9d86ff1a4627ccad8806095828f61989a691f"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.112.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f81aefad1f80ed4132ae33f40b92779eeb57edeb1e28bb24424a4098c963a2"
+
+[[package]]
+name = "cranelift-control"
+version = "0.112.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6adbaac785ad4683c4f199686f9e15c1471f52ae2f4c013a3be039b4719db754"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.112.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b85ed43567e13782cd1b25baf42a8167ee57169a60dfd3d7307c6ca3839da0"
+dependencies = [
+ "cranelift-bitset",
+ "serde 1.0.210",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.112.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8349f71373bb69c6f73992c6c1606236a66c8134e7a60e04e03fbd64b1aa7dcf"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -900,15 +817,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.109.0"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf306d3dde705fb94bd48082f01d38c4ededc74293a4c007805f610bf08bc6e"
+checksum = "464a6b958ce05e0c237c8b25508012b6c644e8c37348213a8c786ba29e28cfdb"
 
 [[package]]
 name = "cranelift-native"
-version = "0.109.0"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea0ebdef7aff4a79bcbc8b6495f31315f16b3bf311152f472eaa8d679352581"
+checksum = "ffc4acaf6894ee323ff4e9ce786bec09f0ebbe49941e8012f1c1052f1d965034"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -917,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.109.0"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d549108a1942065cdbac3bb96c2952afa0e1b9a3beff4b08c4308ac72257576d"
+checksum = "b878860895cca97454ef8d8b12bfda9d0889dd49efee175dba78d54ff8363ec2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -927,7 +844,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-types",
 ]
 
@@ -972,7 +889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -989,36 +906,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1031,19 +924,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
+ "strsim",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1052,9 +934,9 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.10",
+ "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1095,37 +977,6 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -1237,18 +1088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1121,7 @@ dependencies = [
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1333,7 +1172,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1428,7 +1267,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1563,7 +1402,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1631,33 +1470,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 dependencies = [
  "fallible-iterator",
  "indexmap 2.5.0",
@@ -1683,27 +1509,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.5.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1717,7 +1524,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap 2.5.0",
  "slab",
  "tokio",
@@ -1730,15 +1537,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1809,17 +1607,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1840,23 +1627,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -1867,29 +1643,9 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel 1.9.0",
- "base64 0.13.1",
- "futures-lite 1.13.0",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde 1.0.210",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
 ]
 
 [[package]]
@@ -1897,36 +1653,6 @@ name = "httparse"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.7",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
 
 [[package]]
 name = "hyper"
@@ -1937,9 +1663,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1950,34 +1676,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.30",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.4.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.13",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1988,7 +1700,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2005,9 +1717,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.4.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -2068,7 +1780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core 0.6.4",
+ "rand_core",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -2096,12 +1808,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde 1.0.210",
 ]
-
-[[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "inout"
@@ -2175,15 +1881,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2379,7 +2076,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.4",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2468,7 +2165,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2476,16 +2173,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2504,7 +2191,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -2652,34 +2339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.15",
- "http 0.2.12",
- "rand 0.8.5",
- "serde 1.0.210",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror",
- "url",
-]
-
-[[package]]
 name = "object"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,13 +2359,13 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-auth",
  "jwt",
  "lazy_static 1.5.0",
  "olpc-cjson",
  "regex",
- "reqwest 0.12.7",
+ "reqwest",
  "serde 1.0.210",
  "serde_json",
  "sha2",
@@ -2725,13 +2384,13 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-auth",
  "jwt",
  "lazy_static 1.5.0",
  "olpc-cjson",
  "regex",
- "reqwest 0.12.7",
+ "reqwest",
  "serde 1.0.210",
  "serde_json",
  "sha2",
@@ -2815,7 +2474,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3011,7 +2670,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3118,7 +2777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3176,7 +2835,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.87",
  "tempfile",
 ]
 
@@ -3190,7 +2849,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3277,8 +2936,8 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustc-hash",
+ "rustls",
  "socket2 0.5.7",
  "thiserror",
  "tokio",
@@ -3292,10 +2951,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring",
- "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustc-hash",
+ "rustls",
  "slab",
  "thiserror",
  "tinyvec",
@@ -3326,36 +2985,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3365,16 +3001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3383,16 +3010,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -3401,7 +3019,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3439,20 +3057,20 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "libredox",
  "thiserror",
 ]
 
 [[package]]
 name = "regalloc2"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.5",
  "log",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "slice-group-by",
  "smallvec",
 ]
@@ -3503,47 +3121,6 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde 1.0.210",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
@@ -3553,12 +3130,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
- "hyper-rustls 0.27.3",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3570,17 +3147,17 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.13",
- "rustls-pemfile 2.1.3",
+ "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde 1.0.210",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
- "system-configuration 0.6.1",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tokio-socks",
  "tokio-util",
  "tower-service",
@@ -3589,7 +3166,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.6",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -3611,7 +3188,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "libc",
  "spin",
  "untrusted",
@@ -3632,58 +3209,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustify"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c02e25271068de581e03ac3bb44db60165ff1a10d92b9530192ccb898bc706"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "http 0.2.12",
- "reqwest 0.11.27",
- "rustify_derive",
- "serde 1.0.210",
- "serde_json",
- "serde_urlencoded",
- "thiserror",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "rustify_derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345f32672da54338227b727bd578c897859ddfaad8952e0b0d787fb4e58f07d"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "serde_urlencoded",
- "syn 1.0.109",
- "synstructure",
-]
 
 [[package]]
 name = "rustix"
@@ -3716,18 +3244,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
@@ -3736,18 +3252,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3765,16 +3272,6 @@ name = "rustls-pki-types"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -3818,16 +3315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3864,7 +3351,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "serde 1.0.210",
  "sha2",
  "zbus",
@@ -3947,7 +3434,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3963,27 +3450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
-dependencies = [
- "itoa",
- "serde 1.0.210",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde 1.0.210",
- "thiserror",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,7 +3457,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4039,10 +3505,10 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4118,15 +3584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
-dependencies = [
- "dirs 5.0.1",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,7 +3605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4222,21 +3679,19 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spin-app"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
- "async-trait",
  "serde 1.0.210",
  "serde_json",
  "spin-locked-app",
- "thiserror",
 ]
 
 [[package]]
 name = "spin-common"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -4255,11 +3710,12 @@ dependencies = [
  "dialoguer",
  "futures",
  "openssl",
- "reqwest 0.12.7",
+ "reqwest",
  "semver",
  "serde 1.0.210",
  "serde_json",
  "sha2",
+ "spin-common",
  "spin-loader",
  "spin-manifest",
  "spin-serde",
@@ -4269,36 +3725,36 @@ dependencies = [
  "url",
  "wasm-pkg-client",
  "wasm-pkg-common 0.5.1",
- "wasmparser 0.217.0",
+ "wasmparser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
  "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-component 0.217.0",
- "wit-parser 0.217.0",
+ "wit-parser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
 ]
 
 [[package]]
 name = "spin-expressions"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
  "async-trait",
- "serde 1.0.210",
+ "futures",
  "spin-locked-app",
  "thiserror",
 ]
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
  "futures-util",
- "http 1.1.0",
+ "http",
  "ipnet",
- "rustls 0.23.13",
- "rustls-pemfile 2.1.3",
+ "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde 1.0.210",
  "spin-expressions",
@@ -4308,40 +3764,30 @@ dependencies = [
  "spin-locked-app",
  "spin-manifest",
  "spin-serde",
- "terminal",
  "tracing",
  "url",
  "urlencoding",
- "webpki-roots 0.26.6",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "spin-factor-variables"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
- "azure_core",
- "azure_identity",
- "azure_security_keyvault",
- "dotenvy",
- "serde 1.0.210",
  "spin-expressions",
  "spin-factors",
  "spin-world",
- "tokio",
- "toml 0.8.19",
  "tracing",
- "vaultrs",
 ]
 
 [[package]]
 name = "spin-factor-wasi"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "async-trait",
  "bytes",
- "cap-primitives",
  "spin-common",
  "spin-factors",
  "tokio",
@@ -4351,8 +3797,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
  "serde 1.0.210",
@@ -4360,63 +3806,50 @@ dependencies = [
  "spin-factors-derive",
  "thiserror",
  "toml 0.8.19",
- "tracing",
  "wasmtime",
 ]
 
 [[package]]
 name = "spin-factors-derive"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "spin-loader"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
- "async-trait",
- "bytes",
  "dirs 5.0.1",
  "futures",
  "glob",
- "indexmap 2.5.0",
- "itertools 0.13.0",
- "lazy_static 1.5.0",
- "mime_guess",
  "path-absolutize",
- "regex",
- "reqwest 0.12.7",
+ "reqwest",
  "semver",
  "serde 1.0.210",
  "serde_json",
  "sha2",
- "shellexpand 3.1.0",
  "spin-common",
  "spin-factor-outbound-networking",
  "spin-locked-app",
  "spin-manifest",
  "spin-serde",
  "tempfile",
- "terminal",
- "thiserror",
  "tokio",
- "tokio-util",
  "toml 0.8.19",
  "tracing",
- "walkdir",
  "wasm-pkg-loader",
 ]
 
 [[package]]
 name = "spin-locked-app"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4428,8 +3861,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -4445,8 +3878,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4457,8 +3890,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
  "async-trait",
  "wasmtime",
@@ -4494,12 +3927,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4523,20 +3950,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -4548,29 +3969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4578,17 +3976,7 @@ checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -4647,10 +4035,9 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "2.8.0-pre0"
-source = "git+https://github.com/fermyon/spin#6df7262df11bce1046fb838ed2e7b1126c2966c0"
+version = "3.0.0"
+source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
 dependencies = [
- "atty",
  "termcolor",
 ]
 
@@ -4671,7 +4058,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4692,10 +4079,7 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde 1.0.210",
  "time-core",
@@ -4768,7 +4152,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4783,21 +4167,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -4929,7 +4303,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4967,15 +4341,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
 
 [[package]]
 name = "uds_windows"
@@ -5051,7 +4416,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde 1.0.210",
 ]
 
 [[package]]
@@ -5071,29 +4435,6 @@ name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
-dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "vaultrs"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb996bb053adadc767f8b0bda2a80bc2b67d24fe89f2b959ae919e200d79a19"
-dependencies = [
- "async-trait",
- "bytes",
- "derive_builder",
- "http 0.2.12",
- "reqwest 0.11.27",
- "rustify",
- "rustify_derive",
- "serde 1.0.210",
- "serde_json",
- "thiserror",
- "tracing",
- "url",
-]
 
 [[package]]
 name = "vcpkg"
@@ -5184,7 +4525,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "ptree",
- "reqwest 0.12.7",
+ "reqwest",
  "secrecy",
  "semver",
  "serde 1.0.210",
@@ -5230,7 +4571,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "ptree",
- "reqwest 0.12.7",
+ "reqwest",
  "secrecy",
  "semver",
  "serde 1.0.210",
@@ -5267,7 +4608,7 @@ dependencies = [
  "leb128",
  "once_cell",
  "p256",
- "rand_core 0.6.4",
+ "rand_core",
  "secrecy",
  "serde 1.0.210",
  "sha2",
@@ -5288,7 +4629,7 @@ dependencies = [
  "leb128",
  "once_cell",
  "p256",
- "rand_core 0.6.4",
+ "rand_core",
  "secrecy",
  "serde 1.0.210",
  "sha2",
@@ -5410,12 +4751,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -5442,7 +4777,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -5476,7 +4811,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5562,7 +4897,7 @@ version = "0.217.0"
 source = "git+https://github.com/bytecodealliance/wasm-tools#156960bbc3f712c9841345a0f699be32ff1f3c7a"
 dependencies = [
  "leb128",
- "wasmparser 0.217.0",
+ "wasmparser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
 ]
 
 [[package]]
@@ -5625,7 +4960,7 @@ dependencies = [
  "serde_json",
  "spdx",
  "wasm-encoder 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
- "wasmparser 0.217.0",
+ "wasmparser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
 ]
 
 [[package]]
@@ -5669,8 +5004,8 @@ checksum = "ca7a687d110f68a65227a644c7040c7720220e8cb0bb8c803e2b5dcb7fd72468"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
- "http 1.1.0",
- "reqwest 0.12.7",
+ "http",
+ "reqwest",
  "semver",
  "serde 1.0.210",
  "serde_json",
@@ -5689,8 +5024,8 @@ dependencies = [
  "bytes",
  "dirs 5.0.1",
  "futures-util",
- "http 1.1.0",
- "reqwest 0.12.7",
+ "http",
+ "reqwest",
  "semver",
  "serde 1.0.210",
  "serde_json",
@@ -5767,7 +5102,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
  "semver",
- "serde 1.0.210",
 ]
 
 [[package]]
@@ -5799,6 +5133,20 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.217.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
+dependencies = [
+ "ahash",
+ "bitflags 2.6.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.5.0",
+ "semver",
+ "serde 1.0.210",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.217.0"
 source = "git+https://github.com/bytecodealliance/wasm-tools#156960bbc3f712c9841345a0f699be32ff1f3c7a"
 dependencies = [
  "ahash",
@@ -5821,29 +5169,31 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.209.1"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
+checksum = "50dc568b3e0d47e8f96ea547c90790cfa783f0205160c40de894a427114185ce"
 dependencies = [
  "anyhow",
- "wasmparser 0.209.1",
+ "termcolor",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d8b5e7a4d54917c5ebe555b9667337e5f93383f49bddaaeec2eba68093b45"
+checksum = "f38dbf42dc56a6fe41ccd77211ea8ec90855de05e52cd00df5a0a3bca87d6147"
 dependencies = [
- "addr2line 0.21.0",
+ "addr2line 0.22.0",
  "anyhow",
  "async-trait",
+ "bitflags 2.6.0",
  "bumpalo",
  "cc",
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
- "gimli 0.28.1",
+ "gimli 0.29.0",
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
  "ittapi",
@@ -5852,7 +5202,6 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "memoffset 0.9.1",
  "object",
  "once_cell",
  "paste",
@@ -5867,8 +5216,8 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasm-encoder 0.209.1",
- "wasmparser 0.209.1",
+ "wasm-encoder 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -5887,18 +5236,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d697d99c341d4a9ffb72f3af7a02124d233eeb59aee010f36d88e97cca553d5e"
+checksum = "30e0c7f9983c2d60109a939d9ab0e0df301901085c3608e1c22c27c98390a027"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916610f9ae9a6c22deb25bba2e6247ba9f00b093d30620875203b91328a1adfa"
+checksum = "e52eaa50abc14a9a2550d05e99e5e72d43ba75ea99cac1a440b61f1b9b87cd11"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5916,30 +5265,30 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29b462b068e73b5b27fae092a27f47e5937cabf6b26be2779c978698a52feca"
+checksum = "0929ffffaca32dd8770b56848c94056036963ca05de25fb47cac644e20262168"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.209.1",
+ "wit-parser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d2912c53d9054984b380dfbd7579f9c3681b2a73b903a56bd71a1c4f175f1e"
+checksum = "fdc29d2b56629d66d2fd791d1b46471d0016e0d684ed2dc299e870d127082268"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3975deafea000457ba84355c7c0fce0372937204f77026510b7b454f28a3a65"
+checksum = "f8c8af1197703f4de556a274384adf5db36a146f9892bc9607bad16881e75c80"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5949,46 +5298,49 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli 0.28.1",
+ "gimli 0.29.0",
  "log",
  "object",
+ "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f444e900e848b884d8a8a2949b6f5b92af642a3e663ff8fbe78731143a55be61"
+checksum = "3f1b5af7bac868c5bce3b78a366a10677caacf6e6467c156301297e36ed31f3e"
 dependencies = [
  "anyhow",
  "cpp_demangle",
+ "cranelift-bitset",
  "cranelift-entity",
- "gimli 0.28.1",
+ "gimli 0.29.0",
  "indexmap 2.5.0",
  "log",
  "object",
  "postcard",
  "rustc-demangle",
+ "semver",
  "serde 1.0.210",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.209.1",
- "wasmparser 0.209.1",
- "wasmprinter 0.209.1",
+ "wasm-encoder 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmprinter 0.217.0",
  "wasmtime-component-util",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ded58eb2d1bf0dcd2182d0ccd7055c4b10b50d711514f1d73f61515d0fa829d"
+checksum = "665ccc1bb0f28496e6fa02e94c575ee9ad6e3202c7df8591e5dda78106d5aa4a"
 dependencies = [
  "anyhow",
  "cc",
@@ -6001,9 +5353,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc54198c6720f098210a85efb3ba8c078d1de4d373cdb6778850a66ae088d11"
+checksum = "106731c6ebe1d551362ee8c876d450bdc2d517988b20eb3653dc4837b1949437"
 dependencies = [
  "object",
  "once_cell",
@@ -6013,9 +5365,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afe2f0499542f9a4bcfa1b55bfdda803b6ade4e7c93c6b99e0f39dba44b0a91"
+checksum = "5d7314e32c624f645ad7d6b9fc3ac89eb7d2b9aa06695d6445cec087958ec27d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -6025,39 +5377,40 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7de1f2bec5bbb35d532e61c85c049dc84ae671df60492f90b954ecf21169e7"
+checksum = "f75cba1a8cc327839f493cfc3036c9de3d077d59ab76296bc710ee5f95be5391"
 
 [[package]]
 name = "wasmtime-types"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
+checksum = "c6d83a7816947a4974e2380c311eacb1db009b8bad86081dc726b705603c93c7"
 dependencies = [
+ "anyhow",
  "cranelift-entity",
  "serde 1.0.210",
  "serde_derive",
  "smallvec",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5a9bc4f44ceeb168e9e8e3be4e0b4beb9095b468479663a9e24c667e36826f"
+checksum = "6879a8e168aef3fe07335343b7fbede12fa494215e83322e173d4018e124a846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "22.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abb1301089ed8e0b4840f539cba316a73ac382090f1b25d22d8c8eed8df49c7"
+checksum = "ba1497b38341acc97308d6ce784598419fe0131bf6ddc5cda16a91033ef7c66e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6086,16 +5439,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4db238a0241df2d15f79ad17b3a37a27f2ea6cb885894d81b42ae107544466"
+checksum = "6baca2a919a288df653246069868b4de80f07e9679a8ef9b78ad79fc658ffd12"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli 0.28.1",
+ "gimli 0.29.0",
  "object",
  "target-lexicon",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -6103,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "22.0.0"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
+checksum = "3f571f63ac1d532e986eb3973bbef3a45e4ae83de521a8d573b0fe0594dc9608"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.5.0",
- "wit-parser 0.209.1",
+ "wit-parser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6156,12 +5509,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
@@ -6171,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "22.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29830e5d01c182d24b94092c697aa7ab0ee97d22e78a2bf40ca91eae6ebca5c2"
+checksum = "e4ebee2be6b561d1fe91b37e960c02baa94cdee29af863f5f26a0637f344f27a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6186,28 +5533,28 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "22.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557567f2793508760cd855f7659b7a0b9dc4dbc451f53f1415d6943a15311ade"
+checksum = "97c4a32959189041ccb260e6dfa7fcf907e665166e755a6a681c32423c90e45f"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "shellexpand 2.1.2",
- "syn 2.0.77",
+ "shellexpand",
+ "syn 2.0.87",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "22.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc26129a8aea20b62c961d1b9ab4a3c3b56b10042ed85d004f8678af0f21ba6e"
+checksum = "6e1c266e16c4b24a29e055ec651e27fce1389c886bb00fbe78b8924a253a439b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wiggle-generate",
 ]
 
@@ -6244,17 +5591,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.20.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c6915884e731b2db0d8cf08cb64474cb69221a161675fd3c135f91febc3daa"
+checksum = "01cd1dc56c5a45d509ff06e7ca8817eaa9ec3240096f07e71915d5d528658e8a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli 0.28.1",
+ "gimli 0.29.0",
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -6465,16 +5812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "winx"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6491,7 +5828,7 @@ source = "git+https://github.com/fibonacci1729/wit-bindgen?branch=deps#83aa28293
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.217.0",
+ "wit-parser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
 ]
 
 [[package]]
@@ -6503,7 +5840,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.5.0",
  "prettyplease",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-metadata 0.217.0",
  "wit-bindgen-core",
  "wit-component 0.217.0",
@@ -6580,8 +5917,8 @@ dependencies = [
  "serde_json",
  "wasm-encoder 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
  "wasm-metadata 0.217.0",
- "wasmparser 0.217.0",
- "wit-parser 0.217.0",
+ "wasmparser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
+ "wit-parser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
 ]
 
 [[package]]
@@ -6641,6 +5978,24 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.217.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb893dcd6d370cfdf19a0d9adfcd403efb8e544e1a0ea3a8b81a21fe392eaa78"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.5.0",
+ "log",
+ "semver",
+ "serde 1.0.210",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.217.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.217.0"
 source = "git+https://github.com/bytecodealliance/wasm-tools#156960bbc3f712c9841345a0f699be32ff1f3c7a"
 dependencies = [
  "anyhow",
@@ -6652,7 +6007,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.217.0",
+ "wasmparser 0.217.0 (git+https://github.com/bytecodealliance/wasm-tools)",
 ]
 
 [[package]]
@@ -6697,7 +6052,7 @@ dependencies = [
  "async-fs",
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "async-process 1.8.1",
+ "async-process",
  "async-recursion",
  "async-task",
  "async-trait",
@@ -6713,7 +6068,7 @@ dependencies = [
  "nix",
  "once_cell",
  "ordered-stream",
- "rand 0.8.5",
+ "rand",
  "serde 1.0.210",
  "serde_repr",
  "sha1",
@@ -6770,7 +6125,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ reqwest = "0.12.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.8"
-spin-manifest = { git = "https://github.com/fermyon/spin" }
-spin-serde = { git = "https://github.com/fermyon/spin" }
-spin-loader = { git = "https://github.com/fermyon/spin" }
+spin-common = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
+spin-serde = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
 tokio = { version = "1.40.0", features = ["full"] }
 toml = "0.8.19"
 toml_edit = "0.22.21"

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -16,8 +16,8 @@ use wasm_pkg_client::{PackageRef, Registry};
 use wit_parser::{PackageId, Resolve};
 
 use crate::common::{
-    constants::{SPIN_DEPS_WIT_FILE_NAME, SPIN_WIT_DIRECTORY}, interact::{select_multiple_prompt, select_prompt}, manifest::{edit_component_deps_in_manifest, get_component_ids, get_spin_manifest_path}, paths::fs_safe_segment, wit::{
-        get_exported_interfaces, merge_dependecy_package, parse_component_bytes, resolve_to_wit,
+    constants::SPIN_WIT_DIRECTORY, interact::{select_multiple_prompt, select_prompt}, manifest::{edit_component_deps_in_manifest, get_component_ids}, paths::fs_safe_segment, wit::{
+        get_exported_interfaces, parse_component_bytes, resolve_to_wit,
     }
 };
 
@@ -94,14 +94,6 @@ impl ComponentSource {
 
 impl AddCommand {
     pub async fn run(&self) -> Result<()> {
-        let source = ComponentSource::infer_source(&self.source, &self.digest, &self.registry)?;
-
-        let component = source.get_component().await?;
-
-        let (mut resolve, main) = parse_component_bytes(component)?;
-
-        let selected_interfaces = self.select_interfaces(&mut resolve, main)?;
-
         let (manifest_file, distance) = spin_common::paths::find_manifest_file_path(self.manifest_path.as_ref())?;
         if distance > 0 {
             anyhow::bail!(
@@ -109,58 +101,82 @@ impl AddCommand {
                 manifest_file.display()
             );
         }
+        let manifest_file = manifest_file.canonicalize()?;
 
         let mut manifest = manifest_from_file(&manifest_file)?;
 
+        let source = ComponentSource::infer_source(&self.source, &self.digest, &self.registry)?;
+
+        let component = source.get_component().await?;
+
+        let (mut resolve, main) = parse_component_bytes(component)?;
+
+        let selected_interface_map = self.select_interfaces(&mut resolve, main)?;
+        if selected_interface_map.is_empty() {
+            println!("No interfaces selected");
+            return Ok(());
+        }
+
         let selected_component = self.target_component(&manifest)?;
 
-        resolve.importize(
-            resolve.select_world(main, None)?,
-            Some("dependency-world".to_string()),
-        )?;
+        // {
+        //     let package = resolve.packages.get_mut(main).unwrap();
+        //     package.worlds.clear();
 
-        // for interface in &selected_interfaces {
-        //     let interface_wit_dir = PathBuf::from(SPIN_WIT_DIRECTORY).join(fs_safe_segment(interface));
+        //     // let interface_for_naming = &selected_interfaces[0];  // we've already checked the list is non-empty
+        //     package.name = wit_parser::PackageName {
+        //         namespace: "arse".to_owned(),
+        //         name: "biscuits".to_owned(),
+        //         version: semver::Version::parse("1.2.3").ok(),
+        //     };
         // }
 
-        for (id, package) in &resolve.packages {
-            if id == main {
-                continue;
-            }
+        let target_component_id = KebabId::try_from(selected_component.clone()).map_err(|e| anyhow!("{e}"))?;
+        let target_component = manifest.components.get(&target_component_id).ok_or_else(|| anyhow!("component does not exist"))?;
+
+        let root_dir = manifest_file.parent().ok_or_else(|| anyhow!("Manifest cannot be the root directory"))?;
+        
+        // gen bindings
+        for package in selected_interface_map.keys() {
+            // if id != main {
+            //     continue;  // TODO: yes, this is a silly way to just do main
+            // }
+            let id = resolve.packages.iter().find(|(_, p)| &p.name == package).unwrap().0;
 
             let fs_name = fs_safe_segment(package.name.to_string());
 
-            let dep_dir = PathBuf::from(SPIN_WIT_DIRECTORY).join("X-deps-X").join(&fs_name);
+            let dep_dir = PathBuf::from(SPIN_WIT_DIRECTORY).join("deps").join(&fs_name);
             std::fs::create_dir_all(&dep_dir)?;
 
-            let output_wit_file = format!("{ns}-{name}.wit", ns = package.name.namespace, name = package.name.name);
+            let output_wit_file = format!("{ns}-{name}.wit", ns = package.namespace, name = package.name);
             let output_wit_path = dep_dir.join(output_wit_file);
     
             let output_wit_text = resolve_to_wit(&resolve, id).context("failed to resolve to wit")?;
 
             fs::write(&output_wit_path, output_wit_text).await.context("failed to write wit")?;
+
+            // I _think_ we have to generate bindings for *all* the interfaces
+            // because of the possibility of dependencies
+            let interfaces = resolve.packages.iter().flat_map(|(_, p)|
+                p.interfaces.keys().map(|itf_name| qualified_itf_name(&p.name, itf_name))
+            ).collect::<Vec<_>>();
+
+            let target = BindOMatic {
+                // manifest: &manifest,
+                root_dir,
+                target_component,
+                component_id: &selected_component,
+                package_name: &package,
+                interfaces: &interfaces,
+                rel_wit_path: &output_wit_path
+            };
+            try_generate_bindings(&target).await?;
         }
 
-        // let component_dir = PathBuf::from(SPIN_WIT_DIRECTORY).join(&selected_component);
-
-        // let output_wit = component_dir.join(SPIN_DEPS_WIT_FILE_NAME);
-
-        // let base_resolve_file = if std::fs::exists(&output_wit)? {
-        //     Some(&output_wit)
-        // } else {
-        //     fs::create_dir_all(&component_dir).await?;
-        //     None
-        // };
-
-        // let (merged_resolve, main) = merge_dependecy_package(base_resolve_file, &resolve, main)?;
-        // let wit_text = resolve_to_wit(&merged_resolve, main)?;
-        // println!("making wit text");
-        // let wit_text = resolve_to_wit(&resolve, main)?;
-        // println!("writing dep out");
-        // fs::write(output_wit, wit_text).await?;
-
+        let selected_interfaces = selected_interface_map.values().flatten().cloned().collect::<Vec<_>>();
         self.update_manifest(
             source,
+            &manifest_file,
             &mut manifest,
             &selected_component,
             &selected_interfaces,
@@ -174,9 +190,10 @@ impl AddCommand {
         //     root_dir: manifest_file.parent().ok_or_else(|| anyhow!("Manifest cannot be the root directory"))?,
         //     target_component,
         //     component_id: &selected_component,
+        //     package_name: &p,
         //     interfaces: &selected_interfaces
         // };
-        // try_generate_bindings(&target)?;
+        // try_generate_bindings(&target).await?;
 
         Ok(())
     }
@@ -198,7 +215,7 @@ impl AddCommand {
     }
 
     /// Prompts the user to select an interface to import.
-    fn select_interfaces(&self, resolve: &mut Resolve, main: PackageId) -> Result<Vec<String>> {
+    fn select_interfaces(&self, resolve: &mut Resolve, main: PackageId) -> Result<HashMap<wit_parser::PackageName, Vec<String>>> {
         let world_id = resolve.select_world(main, None)?;
         let exported_interfaces = get_exported_interfaces(resolve, world_id);
 
@@ -223,12 +240,13 @@ impl AddCommand {
             &package_names,
         )?;
 
-        let mut selected_interfaces = Vec::new();
+        let mut selected_interface_map = HashMap::new();
 
         for &package_idx in selected_package_indices.iter() {
             let package_name = &package_names[package_idx];
             let interfaces = package_interface_map.get(package_name).unwrap();
             let interface_count = interfaces.len();
+            let mut selected_interfaces = Vec::new();
 
             // If there's only one interface, skip the "Import all" option
             let interface_options: Vec<String> = if interface_count > 1 {
@@ -253,26 +271,23 @@ impl AddCommand {
                 selected_interfaces.push(package_name.to_string());
             } else {
                 let interface_name = &interface_options[selected_interface_idx];
-                let full_itf_name = if let Some(version) = package_name.version.as_ref() {
-                    format!(
-                        "{ns}:{name}/{interface_name}@{version}",
-                        ns = package_name.namespace,
-                        name = package_name.name
-                    )
-                } else {
-                    format!("{package_name}/{interface_name}")
-                };
+                let full_itf_name = qualified_itf_name(package_name, interface_name);
                 selected_interfaces.push(full_itf_name);
+            }
+
+            if !selected_interfaces.is_empty() {
+                selected_interface_map.insert(package_name.clone(), selected_interfaces);
             }
         }
 
-        Ok(selected_interfaces)
+        Ok(selected_interface_map)
     }
 
     /// Updates the manifest file with the new component dependency.
     async fn update_manifest(
         &self,
         source: ComponentSource,
+        manifest_file: &Path,
         manifest: &mut AppManifest,
         selected_component: &str,
         selected_interfaces: &[String],
@@ -306,10 +321,9 @@ impl AddCommand {
         }
 
         let doc =
-            edit_component_deps_in_manifest(selected_component, &component.dependencies).await?;
+            edit_component_deps_in_manifest(manifest_file, selected_component, &component.dependencies).await?;
 
-        let manifest_path = get_spin_manifest_path()?;
-        fs::write(manifest_path, doc).await?;
+        fs::write(manifest_file, doc).await?;
 
         Ok(())
     }
@@ -329,83 +343,167 @@ fn package_name_ver(package_name: &str) -> Result<(PackageRef, Option<VersionReq
     Ok((package.parse()?, version))
 }
 
-// struct BindOMatic<'a> {
-//     // manifest: &'a AppManifest,
-//     root_dir: &'a Path,
-//     target_component: &'a spin_manifest::schema::v2::Component,
-//     component_id: &'a str,
-//     interfaces: &'a [String],
-// }
+fn qualified_itf_name(package_name: &wit_parser::PackageName, interface_name: &str) -> String {
+    if let Some(version) = package_name.version.as_ref() {
+        format!(
+            "{ns}:{name}/{interface_name}@{version}",
+            ns = package_name.namespace,
+            name = package_name.name
+        )
+    } else {
+        format!("{package_name}/{interface_name}")
+    }
+}
 
-// enum Language {
-//     Rust { cargo_toml: PathBuf },
-//     TypeScript { package_json: PathBuf },
-// }
+struct BindOMatic<'a> {
+    // manifest: &'a AppManifest,
+    root_dir: &'a Path,
+    target_component: &'a spin_manifest::schema::v2::Component,
+    component_id: &'a str,
+    package_name: &'a wit_parser::PackageName,
+    interfaces: &'a [String],
+    rel_wit_path: &'a Path,
+}
 
-// impl<'a> BindOMatic<'a> {
-//     fn try_infer_language(&self) -> anyhow::Result<Language> {
-//         let workdir = self.target_component.build.as_ref().and_then(|b| b.workdir.as_ref());
-//         let build_dir = match workdir {
-//             None => self.root_dir.to_owned(),
-//             Some(d) => self.root_dir.join(d),
-//         };
+enum Language {
+    Rust { cargo_toml: PathBuf },
+    #[allow(dead_code)]  // for now
+    TypeScript { package_json: PathBuf },
+}
 
-//         if !build_dir.is_dir() {
-//             bail!("unable to establish build directory for component");
-//         }
+impl<'a> BindOMatic<'a> {
+    fn try_infer_language(&self) -> anyhow::Result<Language> {
+        let workdir = self.target_component.build.as_ref().and_then(|b| b.workdir.as_ref());
+        let build_dir = match workdir {
+            None => self.root_dir.to_owned(),
+            Some(d) => self.root_dir.join(d),
+        };
 
-//         let cargo_toml = build_dir.join("Cargo.toml");
-//         if cargo_toml.is_file() {
-//             return Ok(Language::Rust { cargo_toml });
-//         }
-//         let package_json = build_dir.join("package.json");
-//         if package_json.is_file() {
-//             // TODO: yes also JavaScript
-//             return Ok(Language::TypeScript { package_json });
-//         }
+        if !build_dir.is_dir() {
+            bail!("unable to establish build directory for component (thought it was {build_dir:?})");
+        }
 
-//         Err(anyhow!("unable to determine the component source language"))
-//     }
-// }
+        let cargo_toml = build_dir.join("Cargo.toml");
+        if cargo_toml.is_file() {
+            return Ok(Language::Rust { cargo_toml });
+        }
+        let package_json = build_dir.join("package.json");
+        if package_json.is_file() {
+            // TODO: yes also JavaScript
+            return Ok(Language::TypeScript { package_json });
+        }
 
-// fn try_generate_bindings(target: &BindOMatic) -> anyhow::Result<()> {
-//     match target.try_infer_language()? {
-//         Language::Rust { cargo_toml } => generate_rust_bindings(target.root_dir, &cargo_toml, target.component_id, target.interfaces),
-//         Language::TypeScript { package_json } => todo!(),
-//     }
-// }
+        Err(anyhow!("unable to determine the component source language"))
+    }
+}
 
-// fn generate_rust_bindings(root_dir: &Path, cargo_toml: &Path, component_id: &str, interfaces: &[String]) -> anyhow::Result<()> {
-//     // add wit-bindgen to cargo.toml if needed
-//     let mut did_change = false;
-//     let cargo_text = std::fs::read_to_string(cargo_toml)?;
-//     let mut cargo_doc: toml_edit::DocumentMut = cargo_text.parse()?;
-//     let deps = cargo_doc.entry("dependencies");
-//     match deps {
-//         toml_edit::Entry::Occupied(mut occupied_entry) => {
-//             let Some(deps_table) = occupied_entry.get_mut().as_table_mut() else {
-//                 return Err(anyhow!("existing dependencies table is... not a table"));
-//             };
-//             if !deps_table.contains_key("wit-bindgen") {
-//                 let wbg_ver = toml_edit::Formatted::new("0.34.0".to_owned());
-//                 deps_table.insert("wit-bindgen", toml_edit::Item::Value(toml_edit::Value::String(wbg_ver)));
-//                 did_change = true;
-//             }
-//         },
-//         toml_edit::Entry::Vacant(vacant_entry) => {
-//             let mut deps_table = toml_edit::Table::new();
-//             let wbg_ver = toml_edit::Formatted::new("0.34.0".to_owned());
-//             deps_table.insert("wit-bindgen", toml_edit::Item::Value(toml_edit::Value::String(wbg_ver)));
-//             vacant_entry.insert(toml_edit::Item::Table(deps_table));
-//             did_change = true;
-//         },
-//     };
-//     let new_cargo_text = cargo_doc.to_string();
-//     if did_change {
-//         std::fs::write(cargo_toml, new_cargo_text)?;
-//     }
+async fn try_generate_bindings<'a>(target: &'a BindOMatic<'a>) -> anyhow::Result<()> {
+    match target.try_infer_language()? {
+        Language::Rust { cargo_toml } => generate_rust_bindings(target.root_dir, &cargo_toml, target.component_id, target.package_name, target.interfaces, target.rel_wit_path).await,
+        Language::TypeScript { package_json: _ } => todo!(),
+    }
+}
 
-//     // inject or modify bind script in src/lib.rs
+async fn generate_rust_bindings(root_dir: &Path, cargo_toml: &Path, _component_id: &str, package_name: &wit_parser::PackageName, interfaces: &[String], rel_wit_path: &Path) -> anyhow::Result<()> {
+    // add wit-bindgen to cargo.toml if needed
+    let mut did_change = false;
+    let cargo_text = std::fs::read_to_string(cargo_toml)?;
+    let mut cargo_doc: toml_edit::DocumentMut = cargo_text.parse()?;
+    let deps = cargo_doc.entry("dependencies");
+    match deps {
+        toml_edit::Entry::Occupied(mut occupied_entry) => {
+            let Some(deps_table) = occupied_entry.get_mut().as_table_mut() else {
+                return Err(anyhow!("existing dependencies table is... not a table"));
+            };
+            if !deps_table.contains_key("wit-bindgen") {
+                let wbg_ver = toml_edit::Formatted::new("0.34.0".to_owned());
+                deps_table.insert("wit-bindgen", toml_edit::Item::Value(toml_edit::Value::String(wbg_ver)));
+                did_change = true;
+            }
+        },
+        toml_edit::Entry::Vacant(vacant_entry) => {
+            let mut deps_table = toml_edit::Table::new();
+            let wbg_ver = toml_edit::Formatted::new("0.34.0".to_owned());
+            deps_table.insert("wit-bindgen", toml_edit::Item::Value(toml_edit::Value::String(wbg_ver)));
+            vacant_entry.insert(toml_edit::Item::Table(deps_table));
+            did_change = true;
+        },
+    };
+    let new_cargo_text = cargo_doc.to_string();
+    if did_change {
+        std::fs::write(cargo_toml, new_cargo_text)?;
+    }
+
+    // now set up the bindings
+    let deps_rs_dir = root_dir.join("src/deps");
+    fs::create_dir_all(&deps_rs_dir).await?;
+    let dep_module_name = crate::language::rust::identifier_safe(package_name);
+
+    // step 1: create a module with the generate! macro
+    let imps = interfaces.iter().map(|i| format!(r#"        import {i};"#)).collect::<Vec<_>>();
+    let imps = imps.join("\n");
+    let gens = interfaces.iter().map(|i| format!(r#"        "{i}": generate,"#)).collect::<Vec<_>>();
+    let gens = gens.join("\n");
+    let gen_name = format!("{}-{}", package_name.namespace, package_name.name);
+
+    let binding_file = deps_rs_dir.join(format!("{dep_module_name}.rs"));
+    let gen_macro = include_str!("gen.txt")
+        .replace("{!dep_path!}", format!("{}", rel_wit_path.display()).as_str())
+        .replace("{!imps!}", &imps)
+        .replace("{!gens!}", &gens)
+        .replace("{!gen_name!}", &gen_name);
+    fs::write(&binding_file, gen_macro).await?;
+
+    // step 2: add it to mod.rs
+    let mod_rs_file = deps_rs_dir.join("mod.rs");
+    let dep_module_decl = format!("mod {dep_module_name};");
+
+    let existing = if mod_rs_file.is_file() {
+        fs::read_to_string(&mod_rs_file).await?
+    } else {
+        String::default()
+    };
+
+    if existing.contains(&dep_module_decl) {
+        // nothing to do. No I am not going to worry about if it is commented out, who do you think I am rust-analyzer
+    } else {
+        let separator = if existing.ends_with('\n') {
+            ""
+        } else {
+            ""
+        };
+        let new_mod_rs = format!("{existing}{separator}pub {dep_module_decl}\n");
+        fs::write(mod_rs_file, new_mod_rs).await?;
+    }
+
+    // step 3: add the deps module to lib.rs
+    let lib_rs_file = root_dir.join("src/lib.rs");
+    if lib_rs_file.is_file() {
+        let lib_rs_text = fs::read_to_string(&lib_rs_file).await?;
+        if lib_rs_text.contains("mod deps;") {
+            // nothing to do: again this is super naive for now, e.g if the text is commented out
+        } else {
+            let mut lines: Vec<_> = lib_rs_text.lines().collect();
+            if let Some(last_mod_line) = lines.iter().rposition(|line| line.starts_with("mod ")) {
+                if last_mod_line + 1 >= lines.len() {
+                    // last `mod ...` line is last line of file; push on after it
+                    lines.push("mod deps;");
+                } else {
+                    // last `mod ...` line is within body of file: insert after it
+                    lines.insert(last_mod_line + 1, "mod deps;");
+                }
+            } else {
+                // no existing mod decls, add at beginning
+                lines.insert(0, "mod deps;");
+                lines.insert(1, "");
+            }
+            let new_lib_rs_text = lines.join("\n");
+            fs::write(lib_rs_file, new_lib_rs_text).await?;
+        }
+    }
+
+    Ok(())
+
 //     let lib_file = root_dir.join("src/lib.rs");
 //     if !lib_file.is_file() {
 //         bail!("src/lib.rs is not a file");
@@ -487,5 +585,5 @@ fn package_name_ver(package_name: &str) -> Result<(PackageRef, Option<VersionReq
 //         // TODO: insert this into the file in a SCIENTIFICALLY DETERMINED place
 //     }
 
-//     todo!()
-// }
+    // todo!()
+}

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::Args;
 use http::HttpAddCommand;
 use local::LocalAddCommand;
@@ -9,7 +9,7 @@ use spin_manifest::{
     schema::v2::{AppManifest, ComponentDependency},
 };
 use spin_serde::{DependencyName, DependencyPackageName, KebabId};
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::{Path, PathBuf}};
 use tokio::fs;
 use url::Url;
 use wasm_pkg_client::{PackageRef, Registry};
@@ -38,6 +38,12 @@ pub struct AddCommand {
     /// Registry to override the default with. Ignored in the cases of local or HTTP sources.
     #[clap(short, long)]
     pub registry: Option<Registry>,
+    /// The Spin component to add the dependency to. If omitted, it is prompted for.
+    #[clap(long = "to")]
+    pub add_to_component: Option<String>,
+    /// The path to the manifest. This can be a file or directory. The default is 'spin.toml'.
+    #[clap(short = 'f')]
+    pub manifest_path: Option<PathBuf>,
 }
 
 enum ComponentSource {
@@ -79,6 +85,7 @@ impl ComponentSource {
 
         bail!("Could not infer component source");
     }
+
     pub async fn get_component(&self) -> Result<Vec<u8>> {
         match &self {
             ComponentSource::Local(cmd) => cmd.get_component().await,
@@ -98,21 +105,24 @@ impl AddCommand {
 
         let selected_interfaces = self.select_interfaces(&mut resolve, main)?;
 
-        let mut manifest = manifest_from_file(get_spin_manifest_path()?)?;
-        let component_ids = get_component_ids(&manifest);
-        let selected_component_index = select_prompt(
-            "Select a component to add the dependency to",
-            &component_ids,
-            None,
-        )?;
-        let selected_component = &component_ids[selected_component_index];
+        let (manifest_file, distance) = spin_common::paths::find_manifest_file_path(self.manifest_path.as_ref())?;
+        if distance > 0 {
+            anyhow::bail!(
+                "No spin.toml in current directory - did you mean '-f {}'?",
+                manifest_file.display()
+            );
+        }
+
+        let mut manifest = manifest_from_file(&manifest_file)?;
+
+        let selected_component = self.target_component(&manifest)?;
 
         resolve.importize(
             resolve.select_world(main, None)?,
             Some("dependency-world".to_string()),
         )?;
 
-        let component_dir = PathBuf::from(SPIN_WIT_DIRECTORY).join(selected_component);
+        let component_dir = PathBuf::from(SPIN_WIT_DIRECTORY).join(&selected_component);
 
         let output_wit = component_dir.join(SPIN_DEPS_WIT_FILE_NAME);
 
@@ -130,12 +140,39 @@ impl AddCommand {
         self.update_manifest(
             source,
             &mut manifest,
-            selected_component,
-            selected_interfaces,
+            &selected_component,
+            &selected_interfaces,
         )
         .await?;
 
+        let target_component_id = KebabId::try_from(selected_component.clone()).map_err(|e| anyhow!("{e}"))?;
+        let target_component = manifest.components.get(&target_component_id).ok_or_else(|| anyhow!("component does not exist"))?;
+        let target = BindOMatic {
+            // manifest: &manifest,
+            root_dir: manifest_file.parent().ok_or_else(|| anyhow!("Manifest cannot be the root directory"))?,
+            target_component,
+            component_id: &selected_component,
+            interfaces: &selected_interfaces
+        };
+        try_generate_bindings(&target)?;
+
         Ok(())
+    }
+
+    fn target_component(&self, manifest: &AppManifest) -> anyhow::Result<String> {
+        if let Some(id) = &self.add_to_component {
+            return Ok(id.to_owned())
+        }
+
+        let component_ids = get_component_ids(&manifest);
+        let selected_component_index = select_prompt(
+            "Select a component to add the dependency to",
+            &component_ids,
+            None,
+        )?;
+        let selected_component = &component_ids[selected_component_index];
+
+        Ok(selected_component.clone())
     }
 
     /// Prompts the user to select an interface to import.
@@ -216,7 +253,7 @@ impl AddCommand {
         source: ComponentSource,
         manifest: &mut AppManifest,
         selected_component: &str,
-        selected_interfaces: Vec<String>,
+        selected_interfaces: &[String],
     ) -> Result<()> {
         let id = KebabId::try_from(selected_component.to_owned()).unwrap();
         let component = manifest.components.get_mut(&id).unwrap();
@@ -268,4 +305,165 @@ fn package_name_ver(package_name: &str) -> Result<(PackageRef, Option<VersionReq
         None
     };
     Ok((package.parse()?, version))
+}
+
+struct BindOMatic<'a> {
+    // manifest: &'a AppManifest,
+    root_dir: &'a Path,
+    target_component: &'a spin_manifest::schema::v2::Component,
+    component_id: &'a str,
+    interfaces: &'a [String],
+}
+
+enum Language {
+    Rust { cargo_toml: PathBuf },
+    TypeScript { package_json: PathBuf },
+}
+
+impl<'a> BindOMatic<'a> {
+    fn try_infer_language(&self) -> anyhow::Result<Language> {
+        let workdir = self.target_component.build.as_ref().and_then(|b| b.workdir.as_ref());
+        let build_dir = match workdir {
+            None => self.root_dir.to_owned(),
+            Some(d) => self.root_dir.join(d),
+        };
+
+        if !build_dir.is_dir() {
+            bail!("unable to establish build directory for component");
+        }
+
+        let cargo_toml = build_dir.join("Cargo.toml");
+        if cargo_toml.is_file() {
+            return Ok(Language::Rust { cargo_toml });
+        }
+        let package_json = build_dir.join("package.json");
+        if package_json.is_file() {
+            // TODO: yes also JavaScript
+            return Ok(Language::TypeScript { package_json });
+        }
+
+        Err(anyhow!("unable to determine the component source language"))
+    }
+}
+
+fn try_generate_bindings(target: &BindOMatic) -> anyhow::Result<()> {
+    match target.try_infer_language()? {
+        Language::Rust { cargo_toml } => generate_rust_bindings(target.root_dir, &cargo_toml, target.component_id, target.interfaces),
+        Language::TypeScript { package_json } => todo!(),
+    }
+}
+
+fn generate_rust_bindings(root_dir: &Path, cargo_toml: &Path, component_id: &str, interfaces: &[String]) -> anyhow::Result<()> {
+    // add wit-bindgen to cargo.toml if needed
+    let mut did_change = false;
+    let cargo_text = std::fs::read_to_string(cargo_toml)?;
+    let mut cargo_doc: toml_edit::DocumentMut = cargo_text.parse()?;
+    let deps = cargo_doc.entry("dependencies");
+    match deps {
+        toml_edit::Entry::Occupied(mut occupied_entry) => {
+            let Some(deps_table) = occupied_entry.get_mut().as_table_mut() else {
+                return Err(anyhow!("existing dependencies table is... not a table"));
+            };
+            if !deps_table.contains_key("wit-bindgen") {
+                let wbg_ver = toml_edit::Formatted::new("0.34.0".to_owned());
+                deps_table.insert("wit-bindgen", toml_edit::Item::Value(toml_edit::Value::String(wbg_ver)));
+                did_change = true;
+            }
+        },
+        toml_edit::Entry::Vacant(vacant_entry) => {
+            let mut deps_table = toml_edit::Table::new();
+            let wbg_ver = toml_edit::Formatted::new("0.34.0".to_owned());
+            deps_table.insert("wit-bindgen", toml_edit::Item::Value(toml_edit::Value::String(wbg_ver)));
+            vacant_entry.insert(toml_edit::Item::Table(deps_table));
+            did_change = true;
+        },
+    };
+    let new_cargo_text = cargo_doc.to_string();
+    if did_change {
+        std::fs::write(cargo_toml, new_cargo_text)?;
+    }
+
+    // inject or modify bind script in src/lib.rs
+    let lib_file = root_dir.join("src/lib.rs");
+    if !lib_file.is_file() {
+        bail!("src/lib.rs is not a file");
+    }
+    let lib_text = std::fs::read_to_string(&lib_file)?;
+
+    // ALL RIGHT HERE WE GO
+
+    // If we already have a `mod deps`...
+    if let Some(mod_deps_index) = lib_text.lines().position(|l| l.trim().starts_with("mod deps {")) {
+        // oh no we gotta do some flippin parsing
+        // TODO: can syn help us?  It seemed a bit agonising and not terribly supportive
+        let mut lines: Vec<_> = lib_text.lines().map(|s| s.to_owned()).collect();
+        let mut index = mod_deps_index;
+        let mut in_imports = false;
+        let mut in_with = false;
+        let mut unseen_imports: Vec<_> = interfaces.iter().map(|i| format!("import {i};")).collect();
+        let mut unseen_withs: Vec<_> = interfaces.iter().map(|i| format!("\"{i}\": generate,")).collect();
+        loop {
+            index += 1;
+            let current = &lines[index];
+            if current.trim().starts_with("world imports {") {
+                in_imports = true;
+                continue;
+            }
+            if in_imports {
+                if current.trim().starts_with("}") {
+                    // insert those not yet seen and BUMP INDEX PAST THEM
+                    in_imports = false;
+                    for import in &unseen_imports {
+                        lines.insert(index - 1, format!("            {import}"));
+                        index += 1;
+                    }
+                    continue;;
+                }
+                if current.trim().starts_with("import ") {
+                    // if this was one we were planning to insert, remove it from the plan!
+                    unseen_imports.retain(|imp| imp != current.trim());
+                    continue;
+                }
+            }
+            if current.trim().starts_with("with: {") {
+                in_with = true;
+                continue;
+            }
+            if in_with {
+                if current.trim().ends_with(": generate,") {
+                    // if this was one we were planning to insert, remove it from the plan!
+                    unseen_withs.retain(|w| w != current.trim());
+                    continue;
+                }
+
+            }
+        }
+
+    } else {
+        // We will create a `mod deps` with SCIENCE in it
+        let imps = interfaces.iter().map(|i| format!(r#"            import {i};"#)).collect::<Vec<_>>();
+        let imps = imps.join("\n");
+        let gens = interfaces.iter().map(|i| format!(r#"            "{i}": generate,"#)).collect::<Vec<_>>();
+        let gens = gens.join("\n");
+        let deps_text = format!(r###"
+mod deps {{
+    wit_bindgen::generate!({{
+        inline: r#"
+        package root:component;
+        world imports {{
+{imps}
+        }}
+        "#,
+        with: {{
+{gens}
+        }},
+        path: ".wit/components/{component_id}",
+    }});
+}}
+"###);
+
+        // TODO: insert this into the file in a SCIENTIFICALLY DETERMINED place
+    }
+
+    todo!()
 }

--- a/src/commands/gen.txt
+++ b/src/commands/gen.txt
@@ -1,0 +1,12 @@
+wit_bindgen::generate!({
+    inline: r#"
+    package imported:{!gen_name!};
+    world imports {
+{!imps!}
+    }
+    "#,
+    with: {
+{!gens!}
+    },
+    path: "{!dep_path!}",
+});

--- a/src/commands/gen.txt
+++ b/src/commands/gen.txt
@@ -1,4 +1,4 @@
-wit_bindgen::generate!({
+::spin_sdk::wit_bindgen::generate!({
     inline: r#"
     package imported:{!gen_name!};
     world imports {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod constants;
 pub mod interact;
 pub mod manifest;
+pub mod paths;
 pub mod wit;

--- a/src/common/paths.rs
+++ b/src/common/paths.rs
@@ -1,0 +1,7 @@
+use std::path::Path;
+
+/// Takes a string intended for use as part of a path and makes it
+/// compatible with the local filesystem.
+pub fn fs_safe_segment(segment: String) -> impl AsRef<Path> {
+    segment.replace(':', "-").replace("/", "-")
+}

--- a/src/common/wit.rs
+++ b/src/common/wit.rs
@@ -1,14 +1,6 @@
-use std::path::PathBuf;
-
 use anyhow::{Context, Result};
 use wit_component::WitPrinter;
 use wit_parser::{PackageId, Resolve};
-
-pub const DEFAULT_WIT: &str = r#"package spin-deps:deps@0.1.0;
-
-    world deps {
-    }
-"#;
 
 /// Converts a Resolve object to WIT content.
 pub fn resolve_to_wit(resolve: &Resolve, package_id: PackageId) -> Result<String> {
@@ -56,23 +48,23 @@ pub fn get_exported_interfaces(
         .collect()
 }
 
-pub fn merge_dependecy_package(
-    base_resolve_file: Option<&PathBuf>,
-    dependency_resolve: &Resolve,
-    dependency_pkg_id: PackageId,
-) -> Result<(Resolve, PackageId)> {
-    let mut base_resolve = Resolve::default();
-    let base_resolve_pkg_id = match base_resolve_file {
-        Some(path) => base_resolve.push_file(path)?,
-        None => base_resolve.push_str("base_resolve.wit", DEFAULT_WIT)?,
-    };
-    let base_resolve_world_id = base_resolve.select_world(base_resolve_pkg_id, Some("deps"))?;
+// pub fn merge_dependecy_package(
+//     base_resolve_file: Option<&PathBuf>,
+//     dependency_resolve: &Resolve,
+//     dependency_pkg_id: PackageId,
+// ) -> Result<(Resolve, PackageId)> {
+//     let mut base_resolve = Resolve::default();
+//     let base_resolve_pkg_id = match base_resolve_file {
+//         Some(path) => base_resolve.push_file(path)?,
+//         None => base_resolve.push_str("base_resolve.wit", DEFAULT_WIT)?,
+//     };
+//     let base_resolve_world_id = base_resolve.select_world(base_resolve_pkg_id, Some("deps"))?;
 
-    let dependecy_main_world_id =
-        dependency_resolve.select_world(dependency_pkg_id, Some("dependency-world"))?;
-    let remap = base_resolve.merge(dependency_resolve.clone())?;
-    let dependecy_world_id = remap.map_world(dependecy_main_world_id, None)?;
-    base_resolve.merge_worlds(dependecy_world_id, base_resolve_world_id)?;
+//     let dependecy_main_world_id =
+//         dependency_resolve.select_world(dependency_pkg_id, Some("dependency-world"))?;
+//     let remap = base_resolve.merge(dependency_resolve.clone())?;
+//     let dependecy_world_id = remap.map_world(dependecy_main_world_id, None)?;
+//     base_resolve.merge_worlds(dependecy_world_id, base_resolve_world_id)?;
 
-    Ok((base_resolve, base_resolve_pkg_id))
-}
+//     Ok((base_resolve, base_resolve_pkg_id))
+// }

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -1,0 +1,1 @@
+pub mod rust;

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -1,3 +1,24 @@
 pub fn identifier_safe(package_name: &wit_parser::PackageName) -> String {
     format!("{ns}_{name}", ns = package_name.namespace, name = package_name.name)
 }
+
+// TODO: moar
+const STDLIB_INTERFACES: &[&str] = &[
+    "wasi:io/error@0.2.0",
+    "wasi:io/streams@0.2.0",
+    "wasi:cli/environment@0.2.0",
+    "wasi:cli/exit@0.2.0",
+    "wasi:cli/stdin@0.2.0",
+    "wasi:cli/stdout@0.2.0",
+    "wasi:cli/stderr@0.2.0",
+    "wasi:clocks/wall-clock@0.2.0",
+    "wasi:filesystem/types@0.2.0",
+    "wasi:filesystem/preopens@0.2.0",
+];
+
+// Interfaces that are implemented by stdlib and shouldn't be bound explicitly
+// TODO: We have lost a lot of structure at this point and might want to try
+// to operate on packages but at this point let's just bodge it
+pub fn is_stdlib_known(interface_name: &str) -> bool {
+    STDLIB_INTERFACES.contains(&interface_name)
+}

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -1,0 +1,3 @@
+pub fn identifier_safe(package_name: &wit_parser::PackageName) -> String {
+    format!("{ns}_{name}", ns = package_name.namespace, name = package_name.name)
+}

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -4,8 +4,6 @@ pub fn identifier_safe(package_name: &wit_parser::PackageName) -> String {
 
 // TODO: moar
 const STDLIB_INTERFACES: &[&str] = &[
-    "wasi:io/error@0.2.0",
-    "wasi:io/streams@0.2.0",
     "wasi:cli/environment@0.2.0",
     "wasi:cli/exit@0.2.0",
     "wasi:cli/stdin@0.2.0",
@@ -14,6 +12,17 @@ const STDLIB_INTERFACES: &[&str] = &[
     "wasi:clocks/wall-clock@0.2.0",
     "wasi:filesystem/types@0.2.0",
     "wasi:filesystem/preopens@0.2.0",
+    "wasi:io/error@0.2.0",
+    "wasi:io/streams@0.2.0",
+    "wasi:random/random@0.2.0",
+];
+
+const SPIN_SDK_INTERFACES: &[&str] = &[
+    "wasi:http/incoming-handler@0.2.0",  // TODO: or maybe this is different again
+    "wasi:keyvalue/store@0.2.0-draft2",
+    "wasi:keyvalue/batch@0.2.0-draft2",
+    "wasi:keyvalue/atomics@0.2.0-draft2",
+    "wasi:config/store@0.2.0-draft-2024-09-27",
 ];
 
 // Interfaces that are implemented by stdlib and shouldn't be bound explicitly
@@ -21,4 +30,8 @@ const STDLIB_INTERFACES: &[&str] = &[
 // to operate on packages but at this point let's just bodge it
 pub fn is_stdlib_known(interface_name: &str) -> bool {
     STDLIB_INTERFACES.contains(&interface_name)
+}
+
+pub fn is_sdk_known(interface_name: &str) -> bool {
+    SPIN_SDK_INTERFACES.contains(&interface_name) || interface_name.starts_with("spin:")
 }

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -1,5 +1,9 @@
 pub fn identifier_safe(package_name: &wit_parser::PackageName) -> String {
-    format!("{ns}_{name}", ns = package_name.namespace, name = package_name.name)
+    format!(
+        "{ns}_{name}",
+        ns = package_name.namespace,
+        name = package_name.name
+    )
 }
 
 // TODO: moar
@@ -18,7 +22,7 @@ const STDLIB_INTERFACES: &[&str] = &[
 ];
 
 const SPIN_SDK_INTERFACES: &[&str] = &[
-    "wasi:http/incoming-handler@0.2.0",  // TODO: or maybe this is different again
+    "wasi:http/incoming-handler@0.2.0", // TODO: or maybe this is different again
     "wasi:keyvalue/store@0.2.0-draft2",
     "wasi:keyvalue/batch@0.2.0-draft2",
     "wasi:keyvalue/atomics@0.2.0-draft2",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 
 mod commands;
 mod common;
+mod language;
 use commands::{add::AddCommand, bindings::GenerateBindingsCommand, publish::PublishCommand};
 
 /// Main CLI structure for command-line argument parsing.


### PR DESCRIPTION
The idea with this is instead of separate add-bindings commands and trying to maintain a unified and stateful WIT file, the add command should generate a WIT file per dep and create bindings for that dep in a separate Rust module.  This seemed to work nicely enough for simple cases, but ran into some nasties when the dep imported an interface that got subsetted (and was used elsewhere with a different subset?  My memory is vague).  Anyway sending the PR at @karthik2804's request for him to to include or adapt as he sees fit!
